### PR TITLE
fix #13 #28 - now color changes are kept after reboot without additional configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ ITE Device(8291) is integrated in widely-used Tongfang gaming laptop barebones:
 - HIDevolution EVOC 16GK5 (US reseller)
 - Obsidian GK5CP (PT reseller)
 - Vulcan JinGang GTX Standard
+
 ## Project status
 
 #### Working:
@@ -133,57 +134,6 @@ To disable all keys:
 
 ```bash
 aucc -d
-```
-
-## Add aucc to run on System Startup in 3 steps.
-
-## The following commands need to be executed with root (superuser), or using sudo "command"
-
-### step 1:
-
-create `aucc.service` in `/etc/systemd/system`
-
-```bash
-vi /etc/systemd/system/aucc.service
-```
-
-### step 2:
-
-press i to enter in vim edit mode and paste folow (use the command in "ExecStart" line to specify aucc options):
-
-```bash
-[Unit]
-Description=Avell Keyboard Configuration
-[Service]
-Type=oneshot
-ExecStart=/usr/local/bin/aucc -c red -b 1
-[Install]
-WantedBy=multi-user.target
-```
-
-to write and save the content press `ESC` and hold `Shift+zz`
-
-for more options about customize colors, brightness and styles, folow [Usage](https://github.com/rodgomesc/avell-unofficial-control-center#usage) Instructions
-
-### step 3:
-
-give permissions enable service and put it to work:
-
-```bash
-chmod 755 aucc.service # give permissions
-systemctl enable aucc.service # enable service
-systemctl daemon-reload # reload daemon for apply changes
-systemctl start aucc.service # start service
-systemctl status aucc.service #check status
-```
-
-reboot and enjoy :)
-
-if you want to change something in service file don't forget to reload the daemon and restart service:
-
-```bash
-systemctl daemon-reload
-systemctl restart aucc.service
 ```
 
 ### Thanks to

--- a/aucc/main.py
+++ b/aucc/main.py
@@ -208,8 +208,12 @@ class ControlCenter(DeviceHandler):
         else:
             self.adjust_brightness(4)
 
-    def color_scheme_setup(self):
-        self.ctrl_write(0x12, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00)
+    def color_scheme_setup(self, save_changes=0x01):
+        '''
+        options available: (0x00 for no, 0x01 for yes)
+        purpose: write changes on chip to keep current color on reboot
+        '''
+        self.ctrl_write(0x12, 0x00, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00)
 
     def mono_color_setup(self, color_scheme):
 

--- a/aucc/main.py
+++ b/aucc/main.py
@@ -213,7 +213,7 @@ class ControlCenter(DeviceHandler):
         options available: (0x00 for no, 0x01 for yes)
         purpose: write changes on chip to keep current color on reboot
         '''
-        self.ctrl_write(0x12, 0x00, 0x00, 0x08, 0x01, 0x00, 0x00, 0x00)
+        self.ctrl_write(0x12, 0x00, 0x00, 0x08, save_changes, 0x00, 0x00, 0x00)
 
     def mono_color_setup(self, color_scheme):
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ def find_all(folder):
         for filename in filenames:
             yield os.path.join('..', path, filename)
 
+
 setup(
     name='avell-unofficial-control-center',
-    version='1.0.2',
+    version='1.0.3',
     description='A Project to provide a driver and interface to control keyboard rgb led of ITE 8291 like Avell laptops',  # Required
     entry_points={'console_scripts': [
         'aucc = aucc.main:main']},
@@ -28,8 +29,8 @@ setup(
     package_data={'': list(find_all('aucc'))},
     include_package_data=True,
     install_requires=[
-	'pyusb',
-	'elevate'
+        'pyusb',
+        'elevate'
     ],
     project_urls={
         'Bug Reports': 'https://github.com/rodgomesc/avell-unofficial-control-center/issues',


### PR DESCRIPTION
fix #13 
fix #28 

now current color are kept after reboot by default, 