### PR TITLE
Support multiple devices, set different vendor / product id

### DIFF
--- a/aucc/core/handler.py
+++ b/aucc/core/handler.py
@@ -11,25 +11,13 @@ import sys
 
 
 class Device(object):
-    def __init__(self, vendor_id, product_id):
-
-        self._device = self._get_device(vendor_id, product_id)
+    def __init__(self, device):
+        self._device = device
         self.interface_id = self._get_interface()
         cfg = self._device.get_active_configuration()
 
         self.in_ep = self._get_endpoint(cfg[(1, 0)], usb.util.ENDPOINT_IN)
         self.out_ep = self._get_endpoint(cfg[(1, 0)], usb.util.ENDPOINT_OUT)
-
-    def _get_device(self, vendor, product):
-        device = usb.core.find(idVendor=vendor, idProduct=product)
-        # in linux interface is 1, in windows 0
-        if not sys.platform.startswith('win'):
-            if device.is_kernel_driver_active(1):
-                device.detach_kernel_driver(1)
-        if device is None:
-            raise ValueError('Device not found')
-        else:
-            return device
 
     def _get_interface(self):
         pass
@@ -46,8 +34,8 @@ class Device(object):
 
 
 class DeviceHandler(Device):
-    def __init__(self, vendor_id, product_id):
-        super(DeviceHandler, self).__init__(vendor_id, product_id)
+    def __init__(self, device):
+        super(DeviceHandler, self).__init__(device)
         self.bmRequestType = 0x21
         self.bRequest = 0x09
         self.wValue = 0x300

--- a/aucc/main.py
+++ b/aucc/main.py
@@ -198,9 +198,9 @@ def main():
                         help='Turn keyboard backlight off')
 
     parser.add_argument(
-        '-v', '--vendor', help='Set vendor id (e.g. 1165).', type=int)
+        '-v', '--vendor', help='Set vendor id (e.g. 1165 or 0x048d).', type=str)
     parser.add_argument(
-        '-p', '--product', help='Set product id.', type=int)
+        '-p', '--product', help='Set product id.', type=str)
     parser.add_argument(
         '-D', '--device', help='Select device (1, 2, ...). Use -l to list available devices.', type=int)
     parser.add_argument(
@@ -212,13 +212,17 @@ def main():
 
     vendor_products = {}
     if parsed.vendor:
+        # convert potentially hexadecimal into decimal int
+        vendor = int(parsed.vendor, 0)
         if parsed.product:
-            vendor_products[parsed.vendor] = [parsed.product]
+            product = int(parsed.product, 0)
+            vendor_products[vendor] = [product]
         else:
-            vendor_products[parsed.vendor] = None
+            vendor_products[vendor] = None
     else:
         if parsed.product:
-            vendor_products[0x048d] = [parsed.product]
+            product = int(parsed.product, 0)
+            vendor_products[0x048d] = [product]
         else:
             vendor_products = {0x048d: [0xce00, 0x600b, 0x7001]}
 

--- a/aucc/main.py
+++ b/aucc/main.py
@@ -249,7 +249,7 @@ def main():
             print("No device found")
             sys.exit(1)
         if len(devices) > 1:
-            print("Found multiple devices, please use -d to select one and -l to list them")
+            print("Found multiple devices, please use -D to select one and -l to list them")
             sys.exit(1)
         device = devices[0]
 

--- a/aucc/main.py
+++ b/aucc/main.py
@@ -159,11 +159,6 @@ class ControlCenter(DeviceHandler):
 def main():
     from elevate import elevate
 
-    if not os.geteuid() == 0:
-        elevate()
-
-    control = ControlCenter(vendor_id=0x048d, product_id=0xce00)
-
     parser = argparse.ArgumentParser(
         description=textwrap.dedent('''
             Supply at least one of the options [-c|-H|-V|-s|-d].
@@ -188,6 +183,12 @@ def main():
                         help='Set style speed. 1 is fastest. 10 is slowest')
 
     parsed = parser.parse_args()
+
+    if not os.geteuid() == 0:
+        elevate()
+
+    control = ControlCenter(vendor_id=0x048d, product_id=0xce00)
+
     if parsed.disable:
         control.disable_keyboard()
     else :

--- a/aucc/main.py
+++ b/aucc/main.py
@@ -161,24 +161,24 @@ def main():
 
     parser = argparse.ArgumentParser(
         description=textwrap.dedent('''
-            Supply at least one of the options [-c|-H|-V|-s|-d].
-                
             Colors available:
             [red|green|blue|teal|pink|purple|white|yellow|orange|olive|maroon|brown|gray|skyblue|navy|crimson|darkgreen|lightgreen|gold|violet] '''),
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    parser.add_argument(
-        '-c', '--color', help='Select a single color for all keys.')
+    ops_parser = parser.add_mutually_exclusive_group(required=True)
+    ops_parser.add_argument('-c', '--color',
+                        help='Select a single color for all keys.')
+    ops_parser.add_argument('-H', '--h-alt', metavar='COLOR', nargs=2,
+                        help='Horizontal alternating colors')
+    ops_parser.add_argument('-V', '--v-alt', metavar='COLOR', nargs=2,
+                        help='Vertical alternating colors')
+    ops_parser.add_argument('-s', '--style',
+                        help='One of (rainbow, marquee, wave, raindrop, aurora, random, reactive, breathing, ripple, reactiveripple, reactiveaurora, fireworks). Additional single colors are available for the following styles: raindrop, aurora, random, reactive, breathing, ripple, reactiveripple, reactiveaurora and fireworks. These colors are: Red (r), Orange (o), Yellow (y), Green (g), Blue (b), Teal (t), Purple (p). Append those styles with the start letter of the color you would like (e.g. rippler = Ripple Red')
+    ops_parser.add_argument('-d', '--disable', action='store_true',
+                        help='Turn keyboard backlight off')
+
     parser.add_argument(
         '-b', '--brightness', help='Set brightness, 1 is minimum, 4 is maximum.', type=int, choices=range(1, 5))
-    parser.add_argument('-H', '--h-alt', nargs=2,
-                        help='Horizontal alternating colors')
-    parser.add_argument('-V', '--v-alt', nargs=2,
-                        help='Vertical alternating colors')
-    parser.add_argument('-s', '--style',
-                        help='One of (rainbow, marquee, wave, raindrop, aurora, random, reactive, breathing, ripple, reactiveripple, reactiveaurora, fireworks). Additional single colors are available for the following styles: raindrop, aurora, random, reactive, breathing, ripple, reactiveripple, reactiveaurora and fireworks. These colors are: Red (r), Orange (o), Yellow (y), Green (g), Blue (b), Teal (t), Purple (p). Append those styles with the start letter of the color you would like (e.g. rippler = Ripple Red')
-    parser.add_argument('-d', '--disable', action='store_true',
-                        help='Turn keyboard backlight off')
     parser.add_argument('--speed', type=int, choices=range(1,11),
                         help='Set style speed. 1 is fastest. 10 is slowest')
 


### PR DESCRIPTION
Adds the following features:

- Rework ControlCenter, DeviceHandler and Device class hierarchy
- List available devices
- Allow to select device
- Allow to set vendor and product id
- Add more known to work product ids
- Tell argparse which options are mutually exclusive (if none is given, it exits with help)
- Elevate permissions after args parsed (no need to elevate to print help)